### PR TITLE
[4주차] 조은성 / [feat] 댓글 CRUD 기능 구현

### DIFF
--- a/src/main/java/com/blog/domain/comment/Comment.java
+++ b/src/main/java/com/blog/domain/comment/Comment.java
@@ -1,5 +1,0 @@
-package com.blog.domain.comment;
-
-public class Comment {
-
-}

--- a/src/main/java/com/blog/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/domain/comment/controller/CommentController.java
@@ -1,0 +1,56 @@
+package com.blog.domain.comment.controller;
+
+import com.blog.domain.comment.dto.CommentRequest;
+import com.blog.domain.comment.dto.CommentResponse;
+import com.blog.domain.comment.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/comments")
+public class CommentController {
+  private final CommentService commentService;
+
+  public CommentController(CommentService commentService) {
+    this.commentService = commentService;
+  }
+
+  @PostMapping
+  public ResponseEntity<Map<String, String>> createComment(@RequestBody CommentRequest request) {
+    commentService.createComment(request);
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "댓글 생성 성공");
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<CommentResponse> getComment(@PathVariable UUID id) {
+    return ResponseEntity.ok(commentService.getComment(id));
+  }
+
+  @GetMapping("/post/{postId}")
+  public ResponseEntity<List<CommentResponse>> getCommentsByPostId(@PathVariable UUID postId) {
+    return ResponseEntity.ok(commentService.getCommentsByPostId(postId));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<Map<String, String>> updateComment(@PathVariable UUID id, @RequestBody CommentRequest request) {
+    commentService.updateComment(id, request);
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "댓글 수정 성공");
+    return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Map<String, String>> deleteComment(@PathVariable UUID id) {
+    commentService.deleteComment(id);
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "댓글 삭제 성공");
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/blog/domain/comment/domain/Comment.java
+++ b/src/main/java/com/blog/domain/comment/domain/Comment.java
@@ -1,0 +1,51 @@
+package com.blog.domain.comment.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class Comment {
+  private UUID id;
+  private String content;
+  private UUID authorId;
+  private UUID postId;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public Comment(UUID id, String content, UUID authorId, UUID postId, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    this.id = id;
+    this.content = content;
+    this.authorId = authorId;
+    this.postId = postId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public UUID getAuthorId() {
+    return authorId;
+  }
+
+  public UUID getPostId() {
+    return postId;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void updateContent(String content) {
+    this.content = content;
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/blog/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/blog/domain/comment/dto/CommentRequest.java
@@ -1,0 +1,21 @@
+package com.blog.domain.comment.dto;
+
+import java.util.UUID;
+
+public class CommentRequest {
+  private String content;
+  private UUID postId;
+  private UUID authorId;
+
+  public String getContent() {
+    return content;
+  }
+
+  public UUID getPostId() {
+    return postId;
+  }
+
+  public UUID getAuthorId() {
+    return authorId;
+  }
+}

--- a/src/main/java/com/blog/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/blog/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,58 @@
+package com.blog.domain.comment.dto;
+
+import com.blog.domain.comment.domain.Comment;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class CommentResponse {
+  private UUID id;
+  private String content;
+  private UUID authorId;
+  private UUID postId;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public CommentResponse(UUID id, String content, UUID authorId, UUID postId, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    this.id = id;
+    this.content = content;
+    this.authorId = authorId;
+    this.postId = postId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public static CommentResponse from(Comment comment) {
+    return new CommentResponse(
+        comment.getId(),
+        comment.getContent(),
+        comment.getAuthorId(),
+        comment.getPostId(),
+        comment.getCreatedAt(),
+        comment.getUpdatedAt()
+    );
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public UUID getAuthorId() {
+    return authorId;
+  }
+
+  public UUID getPostId() {
+    return postId;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/src/main/java/com/blog/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/blog/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,69 @@
+package com.blog.domain.comment.repository;
+
+import com.blog.domain.comment.domain.Comment;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class CommentRepository {
+  private final JdbcTemplate jdbcTemplate;
+
+  public CommentRepository(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public void save(Comment comment) {
+    String sql = "INSERT INTO comment (id, content, author_id, post_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)";
+    jdbcTemplate.update(sql,
+        comment.getId().toString(),
+        comment.getContent(),
+        comment.getAuthorId().toString(),
+        comment.getPostId().toString(),
+        Timestamp.valueOf(comment.getCreatedAt()),
+        Timestamp.valueOf(comment.getUpdatedAt())
+    );
+  }
+
+  public Optional<Comment> findById(UUID id) {
+    String sql = "SELECT * FROM comment WHERE id = ?";
+    List<Comment> result = jdbcTemplate.query(sql, commentRowMapper(), id.toString());
+    return result.stream().findFirst();
+  }
+
+  public List<Comment> findByPostId(UUID postId) {
+    String sql = "SELECT * FROM comment WHERE post_id = ?";
+    return jdbcTemplate.query(sql, commentRowMapper(), postId.toString());
+  }
+
+  public void update(Comment comment) {
+    String sql = "UPDATE comment SET content = ?, updated_at = ? WHERE id = ?";
+    jdbcTemplate.update(sql,
+        comment.getContent(),
+        Timestamp.valueOf(comment.getUpdatedAt()),
+        comment.getId().toString()
+    );
+  }
+
+  public void deleteById(UUID id) {
+    String sql = "DELETE FROM comment WHERE id = ?";
+    jdbcTemplate.update(sql, id.toString());
+  }
+
+  private RowMapper<Comment> commentRowMapper() {
+    return (rs, rowNum) -> new Comment(
+        UUID.fromString(rs.getString("id")),
+        rs.getString("content"),
+        UUID.fromString(rs.getString("author_id")),
+        UUID.fromString(rs.getString("post_id")),
+        rs.getTimestamp("created_at").toLocalDateTime(),
+        rs.getTimestamp("updated_at").toLocalDateTime()
+    );
+  }
+}

--- a/src/main/java/com/blog/domain/comment/service/CommentService.java
+++ b/src/main/java/com/blog/domain/comment/service/CommentService.java
@@ -1,0 +1,57 @@
+package com.blog.domain.comment.service;
+
+import com.blog.domain.comment.domain.Comment;
+import com.blog.domain.comment.dto.CommentRequest;
+import com.blog.domain.comment.dto.CommentResponse;
+import com.blog.domain.comment.repository.CommentRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class CommentService {
+  private final CommentRepository commentRepository;
+
+  public CommentService(CommentRepository commentRepository) {
+    this.commentRepository = commentRepository;
+  }
+
+  public void createComment(CommentRequest request) {
+    Comment comment = new Comment(
+        UUID.randomUUID(),
+        request.getContent(),
+        request.getAuthorId(),
+        request.getPostId(),
+        LocalDateTime.now(),
+        LocalDateTime.now()
+    );
+    commentRepository.save(comment);
+  }
+
+  public CommentResponse getComment(UUID id) {
+    Comment comment = commentRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+    return CommentResponse.from(comment);
+  }
+
+  public List<CommentResponse> getCommentsByPostId(UUID postId) {
+    return commentRepository.findByPostId(postId)
+        .stream()
+        .map(CommentResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  public void updateComment(UUID id, CommentRequest request) {
+    Comment comment = commentRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+    comment.updateContent(request.getContent());
+    commentRepository.update(comment);
+  }
+
+  public void deleteComment(UUID id) {
+    commentRepository.deleteById(id);
+  }
+}

--- a/src/main/java/com/blog/domain/post/Post.java
+++ b/src/main/java/com/blog/domain/post/Post.java
@@ -1,5 +1,0 @@
-package com.blog.domain.post;
-
-public class Post {
-
-}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
게시글에 댓글을 작성하고, 조회하고, 수정하고, 삭제할 수 있도록 하기 위해 댓글(Comment) CRUD 기능을 추가했습니다.

사용자 경험 향상을 위해 댓글 생성 및 삭제 시 JSON 형식의 메시지 응답을 추가했습니다.

댓글 API는 JWT 인증을 기반으로 보호하여, 인증된 사용자만 댓글을 작성하거나 관리할 수 있도록 구현했습니다.

## 2. 어떤 위험이나 장애를 발견했나요?
postId 또는 authorId가 잘못된 UUID 형식일 경우 서버에서 400 Bad Request 오류가 발생할 수 있습니다.

존재하지 않는 게시글에 댓글을 작성하거나 존재하지 않는 댓글을 조회/수정/삭제할 경우 404 오류가 발생할 수 있습니다.

현재 작성자 본인 확인 로직이 미구현되어 있어, 인증된 사용자라도 다른 사용자의 댓글을 수정/삭제할 수 있는 잠재적 보안 문제가 있습니다. (추후 수정 예정)

## 3. 관련 스크린샷을 첨부해주세요.

댓글 생성

<img width="847" alt="스크린샷 2025-04-29 오후 10 35 07" src="https://github.com/user-attachments/assets/98fc87bf-c91c-475f-822e-c7a3f3a1c096" />
<img width="1321" alt="스크린샷 2025-04-29 오후 10 39 47" src="https://github.com/user-attachments/assets/dd4c811f-7601-4c3e-bdae-65c45dd6c61b" />


댓글 단건 조회

<img width="851" alt="스크린샷 2025-04-29 오후 10 38 57" src="https://github.com/user-attachments/assets/018ef0c5-d4ee-4f45-ab95-8438049e7421" />


게시글 기준 댓글 목록 조회

<img width="848" alt="스크린샷 2025-04-29 오후 10 45 45" src="https://github.com/user-attachments/assets/f28c0a50-28b4-464b-afc0-855b21439178" />


댓글 수정

<img width="844" alt="스크린샷 2025-04-29 오후 10 50 28" src="https://github.com/user-attachments/assets/9f6c5c6b-8f3d-4c79-bfbd-f17d4a45f9c8" />

댓글 삭제

<img width="845" alt="스크린샷 2025-04-29 오후 10 54 25" src="https://github.com/user-attachments/assets/3c148152-0c8d-4318-92fe-73255249fe7a" />
<img width="1024" alt="스크린샷 2025-04-29 오후 10 55 10" src="https://github.com/user-attachments/assets/74f80e59-ceeb-4752-8313-b09d05b2f6b7" />


## 4. 완료 사항
 댓글 생성 API (POST /comments) 구현

 댓글 단건 조회 API (GET /comments/{commentId}) 구현

 게시글 기준 댓글 목록 조회 API (GET /comments/post/{postId}) 구현

 댓글 수정 API (PUT /comments/{commentId}) 구현

 댓글 삭제 API (DELETE /comments/{commentId}) 구현

 댓글 등록/삭제 시 JSON 메시지 응답 통일

 JWT 인증 기반 API 보호 적용
 
 ## 5. 추가 사항
 closed #62 