### PR TITLE
[4주차] 신은지/ [feat] 댓글 CRUD 기능 구현

### DIFF
--- a/src/main/java/com/blog/BlogApplication.java
+++ b/src/main/java/com/blog/BlogApplication.java
@@ -8,7 +8,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @MapperScan(basePackages = {
 		"com.blog.member.mapper",
 		"com.blog.oauth.mapper",
-		"com.blog.post.mapper"
+		"com.blog.post.mapper",
+		"com.blog.comment.mapper"
 })
 
 public class BlogApplication {

--- a/src/main/java/com/blog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/comment/controller/CommentController.java
@@ -20,6 +20,10 @@ public class CommentController {
     public ResponseEntity<List<CommentRecord>> showComments(
             @RequestParam Integer postId
     ) {
+        // postId가 null이면 명시적인 예외 처리
+        if (postId == null) {
+            throw new IllegalArgumentException("postId 파라미터는 필수입니다.");
+        }
         return ResponseEntity.ok(service.getComments(postId));
     }
 
@@ -30,7 +34,7 @@ public class CommentController {
             @RequestHeader("X-USER-ID") String userId
     ) {
         CommentRecord toInsert = new CommentRecord(
-                null,
+                rec.commentNum(),
                 userId,
                 rec.postId(),
                 rec.content(),
@@ -44,17 +48,17 @@ public class CommentController {
     // 댓글 수정 : 작성자만
     @PutMapping("/edit")
     public ResponseEntity<?> editComment(
-            @RequestBody CommentRecord record,
+            @RequestBody CommentRecord rec,
             @RequestHeader("X-USER-ID") String userId
     ) {
         CommentRecord toUpdate = new CommentRecord(
-                record.commentNum(),
+                rec.commentNum(),
                 userId,
-                record.postId(),
-                record.content(),
-                record.createdAt(),
-                record.updateAt(),
-                record.isDeleted()
+                rec.postId(),
+                rec.content(),
+                rec.createdAt(),
+                rec.updateAt(),
+                rec.isDeleted()
         );
         service.updateComment(toUpdate);
         return ResponseEntity.ok("댓글 수정 완료");
@@ -62,13 +66,14 @@ public class CommentController {
 
     @DeleteMapping("/{commentNum}")
     public ResponseEntity<?> deleteComment(
+            @RequestBody CommentRecord rec,
             @PathVariable Integer commentNum,
             @RequestHeader("X-USER-ID") String userId
     ) {
         CommentRecord toDelete = new CommentRecord(
                 commentNum,
                 userId,
-                null,
+                rec.postId(),
                 null,
                 null,
                 null,

--- a/src/main/java/com/blog/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/comment/controller/CommentController.java
@@ -1,0 +1,97 @@
+package com.blog.comment.controller;
+
+import com.blog.comment.record.CommentRecord;
+import com.blog.comment.service.CommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/comments")
+public class CommentController {
+
+    @Autowired
+    private CommentService service;
+
+    // 댓글 목록 조회
+    @GetMapping("/showComment")
+    public ResponseEntity<List<CommentRecord>> showComments(
+            @RequestParam Integer postId
+    ) {
+        return ResponseEntity.ok(service.getComments(postId));
+    }
+
+    //댓글 작성 (삽입) : 로그인 시에만 가능하다.
+    @PostMapping("/write")
+    public ResponseEntity<Integer> writeComment(
+            @RequestBody CommentRecord rec,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        CommentRecord toInsert = new CommentRecord(
+                null,
+                userId,
+                rec.postId(),
+                rec.content(),
+                null,
+                null,
+                false
+        );
+        return ResponseEntity.ok(service.createComment(toInsert));
+    }
+
+    // 댓글 수정 : 작성자만
+    @PutMapping("/edit")
+    public ResponseEntity<?> editComment(
+            @RequestBody CommentRecord record,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        CommentRecord toUpdate = new CommentRecord(
+                record.commentNum(),
+                userId,
+                record.postId(),
+                record.content(),
+                record.createdAt(),
+                record.updateAt(),
+                record.isDeleted()
+        );
+        service.updateComment(toUpdate);
+        return ResponseEntity.ok("댓글 수정 완료");
+    }
+
+    @DeleteMapping("/{commentNum}")
+    public ResponseEntity<?> deleteComment(
+            @PathVariable Integer commentNum,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        CommentRecord toDelete = new CommentRecord(
+                commentNum,
+                userId,
+                null,
+                null,
+                null,
+                null,
+                false
+        );
+        service.deleteComment(toDelete);
+        return ResponseEntity.ok("댓글 삭제 완료");
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}//class

--- a/src/main/java/com/blog/comment/dao/CommentDao.java
+++ b/src/main/java/com/blog/comment/dao/CommentDao.java
@@ -1,0 +1,86 @@
+package com.blog.comment.dao;
+
+import com.blog.comment.exception.CommentException;
+import com.blog.comment.mapper.CommentMapper;
+import com.blog.comment.record.CommentCreateRecord;
+import com.blog.comment.record.CommentRecord;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class CommentDao {
+
+    @Autowired
+    private CommentMapper mapper;
+
+    /**
+     * 댓글 작성자 ID 조회
+     */
+    public String getWriterId(Integer commentNum) {
+        return mapper.selectWriterId(commentNum);
+    }
+
+    /**
+     * 특정 게시글의 댓글 목록을 조회한다.
+     *
+     * @param postId 게시글 번호
+     * @return 댓글 리스트
+     */
+    public List<CommentRecord> getComments(Integer postId) {
+        return mapper.findByPostId(postId);
+    }
+
+    /**
+     * 댓글을 DB에 저장한다.
+     *
+     * @param record 저장할 CommentRecord
+     * @return 삽입된 행 수
+     */
+    public int insertComment(CommentRecord record) {
+        // record → 생성 전용 record 로 변환
+        CommentCreateRecord param = new CommentCreateRecord(
+                record.memberId(),
+                record.postId(),
+                record.content()
+        );
+        return mapper.insertComment(param);
+    }
+
+    /**
+     * 댓글을 수정한다.
+     *
+     * @param record 수정할 CommentRecord
+     */
+    public void updateComment(CommentRecord record) {
+        if (record.content() == null || record.content().isBlank()) {
+            throw new CommentException("댓글 내용이 비어 있습니다.");
+        }
+        mapper.update(record);
+    }
+
+    /**
+     * 댓글을 소프트 삭제 처리한다.
+     *
+     * @param commentNum 삭제할 댓글 번호
+     */
+    public void deleteComment(Integer commentNum) {
+        mapper.delete(commentNum);
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}//class

--- a/src/main/java/com/blog/comment/dao/CommentDao.java
+++ b/src/main/java/com/blog/comment/dao/CommentDao.java
@@ -28,9 +28,10 @@ public class CommentDao {
      * @param postId 게시글 번호
      * @return 댓글 리스트
      */
-    public List<CommentRecord> getComments(Integer postId) {
+    public List<CommentRecord> getComments(int postId) {
         return mapper.findByPostId(postId);
     }
+
 
     /**
      * 댓글을 DB에 저장한다.

--- a/src/main/java/com/blog/comment/exception/CommentException.java
+++ b/src/main/java/com/blog/comment/exception/CommentException.java
@@ -1,0 +1,23 @@
+package com.blog.comment.exception;
+
+public class CommentException extends RuntimeException{
+
+
+    //메세지만 전달
+    public CommentException(String message) {
+        super(message);
+    }
+
+    //메세지+원인 예외 전달
+    public CommentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+
+
+
+
+
+
+
+}//class

--- a/src/main/java/com/blog/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/blog/comment/mapper/CommentMapper.java
@@ -15,9 +15,9 @@ public interface CommentMapper {
 
     //-------------조회----------------
     //게시글 번호로 댓글 목록 조회
-    List<CommentRecord> findByPostId(@Param("postId") Integer postId);
+    List<CommentRecord> findByPostId(@Param("postId") int postId);
 
-    String selectWriterId(@Param("commentNum") Integer commentNum);
+    String selectWriterId(@Param("commentNum") int commentNum);
 
     //-------------수정----------------
     //댓글 내용 수정
@@ -25,7 +25,7 @@ public interface CommentMapper {
 
     //-------------삭제----------------
     //댓글 소프트 딜리트 삭제
-    int delete(@Param("commentNum") Integer commentNum);
+    int delete(@Param("commentNum") int commentNum);
 
 
 

--- a/src/main/java/com/blog/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/blog/comment/mapper/CommentMapper.java
@@ -1,0 +1,53 @@
+package com.blog.comment.mapper;
+
+import com.blog.comment.record.CommentCreateRecord;
+import com.blog.comment.record.CommentRecord;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface CommentMapper {
+
+    //-------------삽입----------------
+    int insertComment(CommentCreateRecord param);
+
+    //-------------조회----------------
+    //게시글 번호로 댓글 목록 조회
+    List<CommentRecord> findByPostId(@Param("postId") Integer postId);
+
+    String selectWriterId(@Param("commentNum") Integer commentNum);
+
+    //-------------수정----------------
+    //댓글 내용 수정
+    int update(CommentRecord record);
+
+    //-------------삭제----------------
+    //댓글 소프트 딜리트 삭제
+    int delete(@Param("commentNum") Integer commentNum);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}//interface

--- a/src/main/java/com/blog/comment/record/CommentCreateRecord.java
+++ b/src/main/java/com/blog/comment/record/CommentCreateRecord.java
@@ -3,7 +3,7 @@ package com.blog.comment.record;
 public record CommentCreateRecord(
 
         String  memberId,
-        Integer postId,
+        int postId,
         String  content
 
 ) {}//record

--- a/src/main/java/com/blog/comment/record/CommentCreateRecord.java
+++ b/src/main/java/com/blog/comment/record/CommentCreateRecord.java
@@ -1,0 +1,9 @@
+package com.blog.comment.record;
+//댓글 생성에만 쓰임
+public record CommentCreateRecord(
+
+        String  memberId,
+        Integer postId,
+        String  content
+
+) {}//record

--- a/src/main/java/com/blog/comment/record/CommentRecord.java
+++ b/src/main/java/com/blog/comment/record/CommentRecord.java
@@ -1,0 +1,18 @@
+package com.blog.comment.record;
+
+public record CommentRecord(
+
+        Integer commentNum,   // 댓글 식별자 (PK)
+        String memberId,      // 작성자 아이디 (FK to MEMBER.id)
+        Integer postId,       // 게시글 번호 (FK to POST.post_num)
+        String content,       // 댓글 내용
+        String createdAt,     // 생성일 (TIMESTAMP -> 문자열로 처리)
+        String updateAt,      // 수정일 (TIMESTAMP -> 문자열로 처리)
+        Boolean isDeleted     // 삭제 여부
+
+) { }//record
+
+/*
+- created_at, update_at은 단순 JSON 변환을 위해 String으로 처리 (타입 변환은 Mapper에서 핸들링)
+- is_deleted: true면 삭제됨, false면 유지됨 (소프트 삭제 방식)
+* */

--- a/src/main/java/com/blog/comment/record/CommentRecord.java
+++ b/src/main/java/com/blog/comment/record/CommentRecord.java
@@ -2,13 +2,13 @@ package com.blog.comment.record;
 
 public record CommentRecord(
 
-        Integer commentNum,   // 댓글 식별자 (PK)
+        int commentNum,   // 댓글 식별자 (PK)
         String memberId,      // 작성자 아이디 (FK to MEMBER.id)
-        Integer postId,       // 게시글 번호 (FK to POST.post_num)
+        int postId,       // 게시글 번호 (FK to POST.post_num)
         String content,       // 댓글 내용
         String createdAt,     // 생성일 (TIMESTAMP -> 문자열로 처리)
         String updateAt,      // 수정일 (TIMESTAMP -> 문자열로 처리)
-        Boolean isDeleted     // 삭제 여부
+        boolean isDeleted     // 삭제 여부
 
 ) { }//record
 

--- a/src/main/java/com/blog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/comment/service/CommentService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface CommentService {
 
-    List<CommentRecord> getComments(Integer postId);
+    List<CommentRecord> getComments(int postId);
     int    createComment(CommentRecord record);
     void   updateComment(CommentRecord record);
     void   deleteComment(CommentRecord record);

--- a/src/main/java/com/blog/comment/service/CommentService.java
+++ b/src/main/java/com/blog/comment/service/CommentService.java
@@ -1,0 +1,28 @@
+package com.blog.comment.service;
+
+import com.blog.comment.exception.CommentException;
+import com.blog.comment.record.CommentRecord;
+
+import java.util.List;
+
+public interface CommentService {
+
+    List<CommentRecord> getComments(Integer postId);
+    int    createComment(CommentRecord record);
+    void   updateComment(CommentRecord record);
+    void   deleteComment(CommentRecord record);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}//interface

--- a/src/main/java/com/blog/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/blog/comment/service/CommentServiceImpl.java
@@ -1,0 +1,84 @@
+package com.blog.comment.service;
+
+import com.blog.comment.dao.CommentDao;
+import com.blog.comment.exception.CommentException;
+import com.blog.comment.record.CommentRecord;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class CommentServiceImpl implements CommentService{
+
+    @Autowired
+    private CommentDao dao;
+
+    @Override
+    public List<CommentRecord> getComments(Integer postId) {
+        return dao.getComments(postId);
+    }
+
+    @Override
+    @Transactional
+    public int createComment(CommentRecord record) {
+        if (record.content() == null || record.content().isBlank()) {
+            throw new CommentException("댓글 내용이 비어 있습니다.");
+        }
+        return dao.insertComment(record);
+    }
+
+    @Override
+    @Transactional
+    public void updateComment(CommentRecord record) {
+        // 1) DB에서 실제 작성자 조회
+        String writer = dao.getWriterId(record.commentNum());
+        // 2) 헤더로 넘어온 record.memberId() 와 비교
+        if (!writer.equals(record.memberId())) {
+            throw new CommentException("작성자만 수정할 수 있습니다.");
+        }
+        // 3) content 는 이미 record 에 담겨 있으니 바로 호출
+        dao.updateComment(record);
+    }
+
+//    @Override
+//    @Transactional
+//    public void deleteComment(CommentRecord record) {
+//        String writer = dao.getWriterId(record.commentNum());
+//        if (!writer.equals(record.memberId())) {
+//            throw new CommentException("작성자만 삭제할 수 있습니다.");
+//        }
+//        dao.deleteComment(record.commentNum());
+//    }
+
+    @Override
+    @Transactional
+    public void deleteComment(CommentRecord record) {
+        Integer no = record.commentNum();
+        // 1) 작성자 조회
+        String writer = dao.getWriterId(no);
+        // 2) 레코드 자체가 없거나, 매퍼 누락 시 대비
+        if (writer == null) {
+            throw new CommentException("존재하지 않는 댓글입니다.");
+        }
+        // 3) 본인 검증
+        if (!writer.equals(record.memberId())) {
+            throw new CommentException("작성자만 삭제할 수 있습니다.");
+        }
+        // 4) soft delete 수행
+        dao.deleteComment(no);
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+}//class

--- a/src/main/java/com/blog/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/blog/comment/service/CommentServiceImpl.java
@@ -16,7 +16,7 @@ public class CommentServiceImpl implements CommentService{
     private CommentDao dao;
 
     @Override
-    public List<CommentRecord> getComments(Integer postId) {
+    public List<CommentRecord> getComments(int postId) {
         return dao.getComments(postId);
     }
 
@@ -55,7 +55,7 @@ public class CommentServiceImpl implements CommentService{
     @Override
     @Transactional
     public void deleteComment(CommentRecord record) {
-        Integer no = record.commentNum();
+        int no = record.commentNum();
         // 1) 작성자 조회
         String writer = dao.getWriterId(no);
         // 2) 레코드 자체가 없거나, 매퍼 누락 시 대비

--- a/src/main/java/com/blog/post/mapper/PostMapper.java
+++ b/src/main/java/com/blog/post/mapper/PostMapper.java
@@ -24,7 +24,6 @@ public interface PostMapper {
     String selectAuthorId(@Param("postId") Long postId);
 
 
-
     //--------등록-----------
 
     //게시글 등록

--- a/src/main/java/com/blog/post/record/PostRecord.java
+++ b/src/main/java/com/blog/post/record/PostRecord.java
@@ -1,7 +1,7 @@
 package com.blog.post.record;
 
 public record PostRecord<LocalDateTime>(
-        Long id,                    // 게시글 ID
+        Long   id,                    // 게시글 ID
         String title,               // 제목
         String previewContent,      // 내용 요약 (SUBSTRING 처리 등)
         String thumbnailUrl,        // 썸네일 이미지 URL

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -12,6 +12,7 @@
         WHERE comment_num = #{commentNum}
     </select>
 
+
     <insert id="insertComment" parameterType="com.blog.comment.record.CommentCreateRecord">
         INSERT INTO COMMENT (member_id, post_id, content)
         VALUES (#{memberId}, #{postId}, #{content})

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.blog.comment.mapper.CommentMapper">
+
+    <!-- 댓글 작성자 조회 -->
+    <select id="selectWriterId" resultType="String">
+        SELECT member_id
+        FROM COMMENT
+        WHERE comment_num = #{commentNum}
+    </select>
+
+    <insert id="insertComment" parameterType="com.blog.comment.record.CommentCreateRecord">
+        INSERT INTO COMMENT (member_id, post_id, content)
+        VALUES (#{memberId}, #{postId}, #{content})
+    </insert>
+
+
+    <select id="findByPostId" resultType="com.blog.comment.record.CommentRecord">
+        SELECT
+            comment_num AS commentNum,
+            member_id AS memberId,
+            post_id AS postId,
+            content,
+            created_at AS createdAt,
+            updated_at AS updateAt,
+            is_deleted AS isDeleted
+        FROM COMMENT
+        WHERE post_id = #{postId}
+          AND is_deleted = FALSE
+        ORDER BY created_at ASC
+    </select>
+
+    <update id="update" parameterType="com.blog.comment.record.CommentRecord">
+        UPDATE COMMENT
+        SET content = #{content},
+            updated_at = CURRENT_TIMESTAMP
+        WHERE comment_num = #{commentNum}
+    </update>
+
+    <update id="delete">
+        UPDATE COMMENT
+        SET is_deleted = TRUE,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE comment_num = #{commentNum}
+    </update>
+
+</mapper>


### PR DESCRIPTION
# 1. 무슨 이유로 코드를 변경했나요?

MyBatis 매퍼에서 #{memberId} 등 파라미터가 정상 바인딩되지 않아 Parameter 'memberId' not found 오류가 발생해,
CommentCreateRecord를 새로 도입하고 단일 스칼라 파라미터에는 @Param 애노테이션을 명시하여 바인딩 문제를 해결했습니다.

CommentRecord의 commentNum·postId 타입을 ERD(INT)와 일치하도록 Integer로 통일해 타입 불일치 컴파일 에러를 제거했습니다.

XML 매퍼에서 update_at 컬럼명이 실제 스키마의 updated_at과 달라 Unknown column 'update_at' 오류가 났기에, 컬럼명을 수정했습니다.

soft‐delete 로직(is_deleted)에 NULL 값이 들어가면서 조회가 누락되고, 작성자 조회 시 writer == null로 NPE가 발생해,
스키마에 DEFAULT 및 NOT NULL을 설정하고 서비스 레이어에 null 체크를 추가하여 안정성을 높였습니다.

# 2. 어떤 위험이나 장애를 발견했나요?
파라미터 바인딩 실패로 인해 댓글 작성 API가 500 에러를 내고 중단됨.

**타입 불일치(int↔Long)**로 컴파일 에러가 발생하여 서비스 전체가 기동되지 않음.

컬럼명 오타(update_at vs updated_at)로 조회·수정 로직 전반이 작동하지 않는 장애.

soft‐delete 누락 처리(is_deleted=NULL)로 조회에서 정상 댓글이 사라지거나, 삭제 후 NPE 발생.

<!-- 여기에 발견된 위험 요소나 장애 사례를 작성해주세요. 예: “동시성 이슈로 인해 데이터가 중복 저장되는 현상을 확인했습니다.” -->

# 3. 관련 스크린샷을 첨부해주세요.
## 댓글 작성
* 로그인 시
![Image](https://github.com/user-attachments/assets/f6def454-6fc0-4bf0-9129-25bd9f4f92ce)
* 로그아웃 시
![Image](https://github.com/user-attachments/assets/d5a09253-92eb-4b86-891c-0d7892541a23)

## 댓글 조회
![Image](https://github.com/user-attachments/assets/e4861595-661a-4880-8a3a-4cd762f74018)

![image](https://github.com/user-attachments/assets/94f9f231-5e6b-455d-9270-fee94868eeff)


## 댓글 삭제
![Image](https://github.com/user-attachments/assets/604db68e-00e8-4503-a067-f84cb62ca25c)

## 댓글 수정
![Image](https://github.com/user-attachments/assets/91682669-9b96-4ae0-a0c5-12c5ef33e9a1)

![Image](https://github.com/user-attachments/assets/8bf0ffcc-3852-46e5-9837-3db363c42870)


#63 