### PR TITLE
[5주차] 박시현 / [feat] 미구현 API 구현

### DIFF
--- a/src/main/java/com/blog/token/application/TokenServiceImpl.java
+++ b/src/main/java/com/blog/token/application/TokenServiceImpl.java
@@ -1,0 +1,80 @@
+package com.blog.token.application;
+
+import com.blog.token.domain.Token;
+import com.blog.token.domain.TokenRepository;
+import com.blog.token.domain.TokenService;
+import com.blog.token.infrastructure.JwtTokenProvider;
+import com.blog.token.presentation.dto.RefreshTokenRequest;
+import com.blog.token.presentation.dto.TokenResponse;
+import com.blog.user.domain.User;
+import com.blog.user.domain.UserRepository;
+import com.blog.user.presentation.dto.UserResponse;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+
+@Service
+public class TokenServiceImpl implements TokenService {
+
+    private final TokenRepository tokenRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public TokenServiceImpl(TokenRepository tokenRepository, UserRepository userRepository, JwtTokenProvider jwtTokenProvider) {
+        this.tokenRepository = tokenRepository;
+        this.userRepository = userRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public TokenResponse refresh(RefreshTokenRequest request) {
+        String refreshToken = request.getRefreshToken();
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new RuntimeException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        Long userId = Long.parseLong(jwtTokenProvider.parseUserId(refreshToken));
+        Token saved = tokenRepository.findByUserId(userId);
+
+        if (saved == null || !saved.getRefreshToken().equals(refreshToken)) {
+            throw new RuntimeException("토큰이 일치하지 않거나 존재하지 않습니다.");
+        }
+
+        tokenRepository.deleteByUserId(userId);
+
+        User user = userRepository.findById(userId);
+        if (user == null) {
+            throw new RuntimeException("사용자를 찾을 수 없습니다.");
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(user);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
+        Timestamp expiresAt = jwtTokenProvider.getRefreshTokenExpiry();
+
+        Token newToken = new Token(user.getUserId(), newRefreshToken, expiresAt, new Timestamp(System.currentTimeMillis()));
+        tokenRepository.save(newToken);
+
+        UserResponse userResponse = new UserResponse();
+        userResponse.setUserId(user.getUserId());
+        userResponse.setEmail(user.getEmail());
+        userResponse.setName(user.getName());
+        userResponse.setNickname(user.getNickname());
+        userResponse.setProfileImage(user.getProfileImage());
+
+        if (user.getCreatedAt() != null) {
+            userResponse.setCreatedAt(user.getCreatedAt().toString());
+        }
+        if (user.getUpdatedAt() != null) {
+            userResponse.setUpdatedAt(user.getUpdatedAt().toString());
+        }
+
+        TokenResponse response = new TokenResponse();
+        response.setAccessToken(newAccessToken);
+        response.setRefreshToken(newRefreshToken);
+        response.setExpiresAt(expiresAt.toString());
+        response.setUser(userResponse);
+
+        return response;
+    }
+}

--- a/src/main/java/com/blog/token/domain/TokenService.java
+++ b/src/main/java/com/blog/token/domain/TokenService.java
@@ -1,0 +1,8 @@
+package com.blog.token.domain;
+
+import com.blog.token.presentation.dto.RefreshTokenRequest;
+import com.blog.token.presentation.dto.TokenResponse;
+
+public interface TokenService {
+    TokenResponse refresh(RefreshTokenRequest request);
+}

--- a/src/main/java/com/blog/token/presentation/TokenController.java
+++ b/src/main/java/com/blog/token/presentation/TokenController.java
@@ -1,4 +1,24 @@
 package com.blog.token.presentation;
 
+import com.blog.token.domain.TokenService;
+import com.blog.token.presentation.dto.RefreshTokenRequest;
+import com.blog.token.presentation.dto.TokenResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
 public class TokenController {
+
+    private final TokenService tokenService;
+
+    public TokenController(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestBody RefreshTokenRequest request) {
+        TokenResponse response = tokenService.refresh(request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/blog/user/application/UserProfileService.java
+++ b/src/main/java/com/blog/user/application/UserProfileService.java
@@ -1,0 +1,11 @@
+package com.blog.user.application;
+
+import com.blog.user.presentation.dto.UserResponse;
+import com.blog.user.presentation.dto.UserUpdateRequest;
+
+//사용자 정보 관리 전용 인터페이스
+public interface UserProfileService {
+    UserResponse getUser(Long userId); // 조회
+    UserResponse updateUser(Long userId, UserUpdateRequest request); // 수정
+    void deleteUser(Long userId); // 삭제
+}

--- a/src/main/java/com/blog/user/application/UserProfileServiceImpl.java
+++ b/src/main/java/com/blog/user/application/UserProfileServiceImpl.java
@@ -1,0 +1,62 @@
+package com.blog.user.application;
+
+import com.blog.user.domain.User;
+import com.blog.user.domain.UserRepository;
+import com.blog.user.presentation.dto.UserResponse;
+import com.blog.user.presentation.dto.UserUpdateRequest;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+
+@Service
+public class UserProfileServiceImpl implements UserProfileService {
+
+    private final UserRepository userRepository;
+
+    public UserProfileServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserResponse getUser(Long userId) {
+        User user = userRepository.findById(userId);
+        if (user == null || !user.isActive()) {
+            throw new RuntimeException("존재하지 않는 사용자입니다.");
+        }
+
+        UserResponse response = new UserResponse();
+        response.setUserId(user.getUserId());
+        response.setEmail(user.getEmail());
+        response.setName(user.getName());
+        response.setNickname(user.getNickname());
+        response.setProfileImage(user.getProfileImage());
+        response.setCreatedAt(user.getCreatedAt().toString());
+
+        return response;
+    }
+
+    @Override
+    public UserResponse updateUser(Long userId, UserUpdateRequest request) {
+        Timestamp updatedAt = new Timestamp(System.currentTimeMillis());
+        userRepository.update(userId, request.getNickname(), request.getProfileImage(), updatedAt);
+
+        User updated = userRepository.findById(userId);
+        if (updated == null) {
+            throw new RuntimeException("사용자 정보를 수정할 수 없습니다.");
+        }
+
+        UserResponse response = new UserResponse();
+        response.setUserId(updated.getUserId());
+        response.setEmail(updated.getEmail());
+        response.setNickname(updated.getNickname());
+        response.setProfileImage(updated.getProfileImage());
+        response.setUpdatedAt(updated.getUpdatedAt().toString());
+
+        return response;
+    }
+
+    @Override
+    public void deleteUser(Long userId) {
+        userRepository.softDelete(userId);
+    }
+}

--- a/src/main/java/com/blog/user/domain/UserRepository.java
+++ b/src/main/java/com/blog/user/domain/UserRepository.java
@@ -1,9 +1,11 @@
 package com.blog.user.domain;
 
+import java.sql.Timestamp;
+
 public interface UserRepository {
     User findByEmail(String email); // 로그인용
     User findById(Long userId);     // 유저 조회용
     void save(User user);           // 회원가입용
-    void update(User user);         // 정보 수정용
+    void update(Long userId, String nickname, String profileImage, Timestamp updatedAt);         // 정보 수정용
     void softDelete(Long userId);   // 탈퇴용
 }

--- a/src/main/java/com/blog/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/blog/user/infrastructure/UserRepositoryImpl.java
@@ -2,119 +2,70 @@ package com.blog.user.infrastructure;
 
 import com.blog.user.domain.User;
 import com.blog.user.domain.UserRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
-import java.sql.*;
-import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
 
 @Repository
 public class UserRepositoryImpl implements UserRepository {
 
-    private final DataSource dataSource;
+    private final JdbcTemplate jdbcTemplate;
 
-    public UserRepositoryImpl(DataSource dataSource) {
-        this.dataSource = dataSource;
+    public UserRepositoryImpl(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void save(User user) {
+        String sql = "INSERT INTO users (email, password, name, nickname, birth_date, profile_image, introduction, auth_method, created_at, updated_at, is_active) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(sql,
+                user.getEmail(),
+                user.getPassword(),
+                user.getName(),
+                user.getNickname(),
+                user.getBirthDate(),
+                user.getProfileImage(),
+                user.getIntroduction(),
+                user.getAuthMethod(),
+                user.getCreatedAt(),
+                user.getUpdatedAt(),
+                user.isActive()
+        );
     }
 
     @Override
     public User findByEmail(String email) {
         String sql = "SELECT * FROM users WHERE email = ?";
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
-
-            ps.setString(1, email);
-            ResultSet rs = ps.executeQuery();
-
-            if (rs.next()) {
-                return mapRowToUser(rs);
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-        return null;
+        return jdbcTemplate.query(sql, new Object[]{email}, userRowMapper())
+                .stream().findFirst().orElse(null);
     }
 
     @Override
     public User findById(Long userId) {
         String sql = "SELECT * FROM users WHERE user_id = ?";
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
-
-            ps.setLong(1, userId);
-            ResultSet rs = ps.executeQuery();
-
-            if (rs.next()) {
-                return mapRowToUser(rs);
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-        return null;
+        return jdbcTemplate.query(sql, new Object[]{userId}, userRowMapper())
+                .stream().findFirst().orElse(null);
     }
 
     @Override
-    public void save(User user) {
-        String sql = "INSERT INTO users (email, password, name, nickname, birth_date, profile_image, introduction, auth_method, created_at, updated_at, is_active) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
-
-            ps.setString(1, user.getEmail());
-            ps.setString(2, user.getPassword());
-            ps.setString(3, user.getName());
-            ps.setString(4, user.getNickname());
-            ps.setString(5, user.getBirthDate());
-            ps.setString(6, user.getProfileImage());
-            ps.setString(7, user.getIntroduction());
-            ps.setString(8, user.getAuthMethod());
-            ps.setTimestamp(9, user.getCreatedAt());
-            ps.setTimestamp(10, user.getUpdatedAt());
-            ps.setBoolean(11, user.isActive());
-
-            ps.executeUpdate();
-
-            ResultSet keys = ps.getGeneratedKeys();
-            if (keys.next()) {
-                user.setUserId(keys.getLong(1));
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    public void update(User user) {
-        String sql = "UPDATE users SET nickname = ?, profile_image = ?, introduction = ?, updated_at = ? WHERE user_id = ?";
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
-
-            ps.setString(1, user.getNickname());
-            ps.setString(2, user.getProfileImage());
-            ps.setString(3, user.getIntroduction());
-            ps.setTimestamp(4, user.getUpdatedAt());
-            ps.setLong(5, user.getUserId());
-
-            ps.executeUpdate();
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+    public void update(Long userId, String nickname, String profileImage, Timestamp updatedAt) {
+        String sql = "UPDATE users SET nickname = ?, profile_image = ?, updated_at = ? WHERE user_id = ?";
+        jdbcTemplate.update(sql, nickname, profileImage, updatedAt, userId);
     }
 
     @Override
     public void softDelete(Long userId) {
         String sql = "UPDATE users SET is_active = false WHERE user_id = ?";
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(sql)) {
-
-            ps.setLong(1, userId);
-            ps.executeUpdate();
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        jdbcTemplate.update(sql, userId);
     }
 
-    private User mapRowToUser(ResultSet rs) throws SQLException {
-        return new User(
+    private RowMapper<User> userRowMapper() {
+        return (rs, rowNum) -> new User(
                 rs.getLong("user_id"),
                 rs.getString("email"),
                 rs.getString("password"),

--- a/src/main/java/com/blog/user/presentation/UserProfileController.java
+++ b/src/main/java/com/blog/user/presentation/UserProfileController.java
@@ -1,0 +1,53 @@
+package com.blog.user.presentation;
+
+import com.blog.user.application.UserProfileService;
+import com.blog.token.infrastructure.JwtTokenProvider;
+import com.blog.user.presentation.dto.UserResponse;
+import com.blog.user.presentation.dto.UserUpdateRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+public class UserProfileController {
+
+    private final UserProfileService userProfileService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public UserProfileController(UserProfileService userProfileService, JwtTokenProvider jwtTokenProvider) {
+        this.userProfileService = userProfileService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    // 유저 정보 조회
+    @GetMapping
+    public ResponseEntity<UserResponse> getUser(@RequestHeader("Authorization") String token) {
+        Long userId = extractUserId(token);
+        return ResponseEntity.ok(userProfileService.getUser(userId));
+    }
+
+    // 유저 정보 수정
+    @PutMapping
+    public ResponseEntity<UserResponse> updateUser(
+            @RequestHeader("Authorization") String token,
+            @RequestBody UserUpdateRequest request
+    ) {
+        Long userId = extractUserId(token);
+        return ResponseEntity.ok(userProfileService.updateUser(userId, request));
+    }
+
+    // 유저 삭제
+    @DeleteMapping
+    public ResponseEntity<Void> deleteUser(@RequestHeader("Authorization") String token) {
+        Long userId = extractUserId(token);
+        userProfileService.deleteUser(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    private Long extractUserId(String token) {
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+        return Long.parseLong(jwtTokenProvider.parseUserId(token));
+    }
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- Refresh Token 재발급 안정화
    - 기존에는 로그인할 때마다 refresh_token이 중복 저장되어, 이전 토큰으로는 /auth/refresh 실패 발생
    - 사용자당 하나의 refresh_token만 유지되도록 deleteByUserId()를 통해 중복 제거 처리
    - 로그인 / 토큰 재발급 시 기존 토큰을 먼저 삭제 후 새로운 토큰 저장
- User 정보 관리 기능 추가
    - 사용자 정보 조회, 수정, 삭제(soft delete) API 구현
    - 로그인한 사용자의 토큰(Authorization: Bearer) 기반으로 자기 정보만 수정/삭제 가능
    - UserProfileService, UserProfileController로 역할 분리 및 의존성 최소화

</br>

## 2. 어떤 위험이나 장애를 발견했나요?
- refresh_token이 계속 insert되면서 DB에 중복 토큰이 누적됨 → 잘못된 토큰으로 요청 시 500 에러
- 수정/삭제 시 토큰 검증 없이 userId를 직접 전달받게 되면 보안 이슈 발생 가능
- 유저 정보 GET /user 호출 시 비활성 유저도 조회되는 문제 가능성 → is_active 체크 로직 추가함

</br>

## 3. 관련 스크린샷을 첨부해주세요.
- Refresh Token 재발급
<img width="652" alt="image1" src="https://github.com/user-attachments/assets/9034301c-d136-4197-8700-a34730370506" />
- User 조회
<img width="647" alt="image2" src="https://github.com/user-attachments/assets/87e2e6c6-db35-45c6-a5df-d43d3a0320fc" />
- User 수정
<img width="650" alt="image3" src="https://github.com/user-attachments/assets/49fae9e9-86cd-48ea-a97b-a5210cb919df" />
- User 삭제
<img width="639" alt="image4" src="https://github.com/user-attachments/assets/8b694792-b5c5-4817-9255-dc9d93eef593" />

closed #70 