### PR TITLE
[5주차] 조은성 / [feat] 미구현 API 구현

### DIFF
--- a/src/main/java/com/blog/domain/comment/Comment.java
+++ b/src/main/java/com/blog/domain/comment/Comment.java
@@ -1,5 +1,0 @@
-package com.blog.domain.comment;
-
-public class Comment {
-
-}

--- a/src/main/java/com/blog/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/domain/comment/controller/CommentController.java
@@ -1,0 +1,56 @@
+package com.blog.domain.comment.controller;
+
+import com.blog.domain.comment.dto.CommentRequest;
+import com.blog.domain.comment.dto.CommentResponse;
+import com.blog.domain.comment.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/comments")
+public class CommentController {
+  private final CommentService commentService;
+
+  public CommentController(CommentService commentService) {
+    this.commentService = commentService;
+  }
+
+  @PostMapping
+  public ResponseEntity<Map<String, String>> createComment(@RequestBody CommentRequest request) {
+    commentService.createComment(request);
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "댓글 생성 성공");
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<CommentResponse> getComment(@PathVariable UUID id) {
+    return ResponseEntity.ok(commentService.getComment(id));
+  }
+
+  @GetMapping("/post/{postId}")
+  public ResponseEntity<List<CommentResponse>> getCommentsByPostId(@PathVariable UUID postId) {
+    return ResponseEntity.ok(commentService.getCommentsByPostId(postId));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<Map<String, String>> updateComment(@PathVariable UUID id, @RequestBody CommentRequest request) {
+    commentService.updateComment(id, request);
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "댓글 수정 성공");
+    return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Map<String, String>> deleteComment(@PathVariable UUID id) {
+    commentService.deleteComment(id);
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "댓글 삭제 성공");
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/blog/domain/comment/domain/Comment.java
+++ b/src/main/java/com/blog/domain/comment/domain/Comment.java
@@ -1,0 +1,51 @@
+package com.blog.domain.comment.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class Comment {
+  private UUID id;
+  private String content;
+  private UUID authorId;
+  private UUID postId;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public Comment(UUID id, String content, UUID authorId, UUID postId, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    this.id = id;
+    this.content = content;
+    this.authorId = authorId;
+    this.postId = postId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public UUID getAuthorId() {
+    return authorId;
+  }
+
+  public UUID getPostId() {
+    return postId;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void updateContent(String content) {
+    this.content = content;
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/blog/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/blog/domain/comment/dto/CommentRequest.java
@@ -1,0 +1,21 @@
+package com.blog.domain.comment.dto;
+
+import java.util.UUID;
+
+public class CommentRequest {
+  private String content;
+  private UUID postId;
+  private UUID authorId;
+
+  public String getContent() {
+    return content;
+  }
+
+  public UUID getPostId() {
+    return postId;
+  }
+
+  public UUID getAuthorId() {
+    return authorId;
+  }
+}

--- a/src/main/java/com/blog/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/blog/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,58 @@
+package com.blog.domain.comment.dto;
+
+import com.blog.domain.comment.domain.Comment;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class CommentResponse {
+  private UUID id;
+  private String content;
+  private UUID authorId;
+  private UUID postId;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public CommentResponse(UUID id, String content, UUID authorId, UUID postId, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    this.id = id;
+    this.content = content;
+    this.authorId = authorId;
+    this.postId = postId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public static CommentResponse from(Comment comment) {
+    return new CommentResponse(
+        comment.getId(),
+        comment.getContent(),
+        comment.getAuthorId(),
+        comment.getPostId(),
+        comment.getCreatedAt(),
+        comment.getUpdatedAt()
+    );
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public UUID getAuthorId() {
+    return authorId;
+  }
+
+  public UUID getPostId() {
+    return postId;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/src/main/java/com/blog/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/blog/domain/comment/repository/CommentRepository.java
@@ -66,4 +66,10 @@ public class CommentRepository {
         rs.getTimestamp("updated_at").toLocalDateTime()
     );
   }
+
+  public List<Comment> findByAuthorId(UUID authorId) {
+    String sql = "SELECT * FROM comment WHERE author_id = ?";
+    return jdbcTemplate.query(sql, commentRowMapper(), authorId.toString());
+  }
+
 }

--- a/src/main/java/com/blog/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/blog/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,69 @@
+package com.blog.domain.comment.repository;
+
+import com.blog.domain.comment.domain.Comment;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class CommentRepository {
+  private final JdbcTemplate jdbcTemplate;
+
+  public CommentRepository(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public void save(Comment comment) {
+    String sql = "INSERT INTO comment (id, content, author_id, post_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)";
+    jdbcTemplate.update(sql,
+        comment.getId().toString(),
+        comment.getContent(),
+        comment.getAuthorId().toString(),
+        comment.getPostId().toString(),
+        Timestamp.valueOf(comment.getCreatedAt()),
+        Timestamp.valueOf(comment.getUpdatedAt())
+    );
+  }
+
+  public Optional<Comment> findById(UUID id) {
+    String sql = "SELECT * FROM comment WHERE id = ?";
+    List<Comment> result = jdbcTemplate.query(sql, commentRowMapper(), id.toString());
+    return result.stream().findFirst();
+  }
+
+  public List<Comment> findByPostId(UUID postId) {
+    String sql = "SELECT * FROM comment WHERE post_id = ?";
+    return jdbcTemplate.query(sql, commentRowMapper(), postId.toString());
+  }
+
+  public void update(Comment comment) {
+    String sql = "UPDATE comment SET content = ?, updated_at = ? WHERE id = ?";
+    jdbcTemplate.update(sql,
+        comment.getContent(),
+        Timestamp.valueOf(comment.getUpdatedAt()),
+        comment.getId().toString()
+    );
+  }
+
+  public void deleteById(UUID id) {
+    String sql = "DELETE FROM comment WHERE id = ?";
+    jdbcTemplate.update(sql, id.toString());
+  }
+
+  private RowMapper<Comment> commentRowMapper() {
+    return (rs, rowNum) -> new Comment(
+        UUID.fromString(rs.getString("id")),
+        rs.getString("content"),
+        UUID.fromString(rs.getString("author_id")),
+        UUID.fromString(rs.getString("post_id")),
+        rs.getTimestamp("created_at").toLocalDateTime(),
+        rs.getTimestamp("updated_at").toLocalDateTime()
+    );
+  }
+}

--- a/src/main/java/com/blog/domain/comment/service/CommentService.java
+++ b/src/main/java/com/blog/domain/comment/service/CommentService.java
@@ -54,4 +54,12 @@ public class CommentService {
   public void deleteComment(UUID id) {
     commentRepository.deleteById(id);
   }
+
+  public List<CommentResponse> getCommentsByAuthor(UUID authorId) {
+    return commentRepository.findByAuthorId(authorId)
+        .stream()
+        .map(CommentResponse::from)
+        .collect(Collectors.toList());
+  }
+
 }

--- a/src/main/java/com/blog/domain/comment/service/CommentService.java
+++ b/src/main/java/com/blog/domain/comment/service/CommentService.java
@@ -1,0 +1,57 @@
+package com.blog.domain.comment.service;
+
+import com.blog.domain.comment.domain.Comment;
+import com.blog.domain.comment.dto.CommentRequest;
+import com.blog.domain.comment.dto.CommentResponse;
+import com.blog.domain.comment.repository.CommentRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class CommentService {
+  private final CommentRepository commentRepository;
+
+  public CommentService(CommentRepository commentRepository) {
+    this.commentRepository = commentRepository;
+  }
+
+  public void createComment(CommentRequest request) {
+    Comment comment = new Comment(
+        UUID.randomUUID(),
+        request.getContent(),
+        request.getAuthorId(),
+        request.getPostId(),
+        LocalDateTime.now(),
+        LocalDateTime.now()
+    );
+    commentRepository.save(comment);
+  }
+
+  public CommentResponse getComment(UUID id) {
+    Comment comment = commentRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+    return CommentResponse.from(comment);
+  }
+
+  public List<CommentResponse> getCommentsByPostId(UUID postId) {
+    return commentRepository.findByPostId(postId)
+        .stream()
+        .map(CommentResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  public void updateComment(UUID id, CommentRequest request) {
+    Comment comment = commentRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+    comment.updateContent(request.getContent());
+    commentRepository.update(comment);
+  }
+
+  public void deleteComment(UUID id) {
+    commentRepository.deleteById(id);
+  }
+}

--- a/src/main/java/com/blog/domain/image/Image.java
+++ b/src/main/java/com/blog/domain/image/Image.java
@@ -1,5 +1,0 @@
-package com.blog.domain.image;
-
-public class Image {
-
-}

--- a/src/main/java/com/blog/domain/image/controller/ImageController.java
+++ b/src/main/java/com/blog/domain/image/controller/ImageController.java
@@ -1,0 +1,23 @@
+package com.blog.domain.image.controller;
+
+import com.blog.domain.image.dto.ImageResponse;
+import com.blog.domain.image.service.ImageService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/images")
+public class ImageController {
+  private final ImageService imageService;
+
+  public ImageController(ImageService imageService) {
+    this.imageService = imageService;
+  }
+
+  @PostMapping("/upload")
+  public ResponseEntity<ImageResponse> upload(@RequestParam("file") MultipartFile file) {
+    ImageResponse response = imageService.upload(file);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/blog/domain/image/domain/Image.java
+++ b/src/main/java/com/blog/domain/image/domain/Image.java
@@ -1,0 +1,40 @@
+package com.blog.domain.image.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class Image {
+  private UUID id;
+  private String originalName;
+  private String storedName;
+  private String url;
+  private LocalDateTime createdAt;
+
+  public Image(UUID id, String originalName, String storedName, String url, LocalDateTime createdAt) {
+    this.id = id;
+    this.originalName = originalName;
+    this.storedName = storedName;
+    this.url = url;
+    this.createdAt = createdAt;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getOriginalName() {
+    return originalName;
+  }
+
+  public String getStoredName() {
+    return storedName;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/src/main/java/com/blog/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/blog/domain/image/dto/ImageResponse.java
@@ -1,0 +1,27 @@
+package com.blog.domain.image.dto;
+
+import com.blog.domain.image.domain.Image;
+
+import java.util.UUID;
+
+public class ImageResponse {
+  private UUID id;
+  private String url;
+
+  public ImageResponse(UUID id, String url) {
+    this.id = id;
+    this.url = url;
+  }
+
+  public static ImageResponse from(Image image) {
+    return new ImageResponse(image.getId(), image.getUrl());
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+}

--- a/src/main/java/com/blog/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/blog/domain/image/repository/ImageRepository.java
@@ -1,0 +1,45 @@
+package com.blog.domain.image.repository;
+
+import com.blog.domain.image.domain.Image;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class ImageRepository {
+  private final JdbcTemplate jdbcTemplate;
+
+  public ImageRepository(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public void save(Image image) {
+    String sql = "INSERT INTO image (id, original_name, stored_name, url, created_at) VALUES (?, ?, ?, ?, ?)";
+    jdbcTemplate.update(sql,
+        image.getId().toString(),
+        image.getOriginalName(),
+        image.getStoredName(),
+        image.getUrl(),
+        Timestamp.valueOf(image.getCreatedAt()));
+  }
+
+  public Optional<Image> findById(UUID id) {
+    String sql = "SELECT * FROM image WHERE id = ?";
+    return jdbcTemplate.query(sql, rowMapper(), id.toString())
+        .stream().findFirst();
+  }
+
+  private RowMapper<Image> rowMapper() {
+    return (rs, rowNum) -> new Image(
+        UUID.fromString(rs.getString("id")),
+        rs.getString("original_name"),
+        rs.getString("stored_name"),
+        rs.getString("url"),
+        rs.getTimestamp("created_at").toLocalDateTime()
+    );
+  }
+}

--- a/src/main/java/com/blog/domain/image/service/ImageService.java
+++ b/src/main/java/com/blog/domain/image/service/ImageService.java
@@ -1,0 +1,49 @@
+package com.blog.domain.image.service;
+
+import com.blog.domain.image.domain.Image;
+import com.blog.domain.image.dto.ImageResponse;
+import com.blog.domain.image.repository.ImageRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+public class ImageService {
+  private static final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/";
+  private final ImageRepository imageRepository;
+
+  public ImageService(ImageRepository imageRepository) {
+    this.imageRepository = imageRepository;
+  }
+  public ImageResponse upload(MultipartFile file) {
+    try {
+      String originalName = file.getOriginalFilename();
+      String ext = originalName.substring(originalName.lastIndexOf("."));
+      String storedName = UUID.randomUUID() + ext;
+      Path storedPath = Path.of(UPLOAD_DIR + storedName);
+
+      Files.createDirectories(storedPath.getParent()); // 디렉토리 없으면 생성
+      file.transferTo(storedPath.toFile());
+
+      String url = "/images/" + storedName;
+
+      Image image = new Image(
+          UUID.randomUUID(),
+          originalName,
+          storedName,
+          url,
+          LocalDateTime.now()
+      );
+
+      imageRepository.save(image);
+      return ImageResponse.from(image);
+    } catch (Exception e) {
+      throw new RuntimeException("이미지 저장 실패", e);
+    }
+  }
+}

--- a/src/main/java/com/blog/domain/post/Post.java
+++ b/src/main/java/com/blog/domain/post/Post.java
@@ -1,5 +1,0 @@
-package com.blog.domain.post;
-
-public class Post {
-
-}

--- a/src/main/java/com/blog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/blog/domain/post/repository/PostRepository.java
@@ -67,4 +67,10 @@ public class PostRepository {
         rs.getTimestamp("updated_at").toLocalDateTime()
     );
   }
+
+  public List<Post> findByAuthorId(String authorId) {
+    String sql = "SELECT * FROM post WHERE author_id = ?";
+    return jdbcTemplate.query(sql, postRowMapper(), authorId);
+  }
+
 }

--- a/src/main/java/com/blog/domain/post/service/PostService.java
+++ b/src/main/java/com/blog/domain/post/service/PostService.java
@@ -64,4 +64,12 @@ public class PostService {
   public void deletePost(UUID id) {
     postRepository.deleteById(id);
   }
+
+  public List<PostResponse> getPostsByAuthor(UUID authorId) {
+    return postRepository.findByAuthorId(authorId.toString())
+        .stream()
+        .map(PostResponse::from)
+        .collect(Collectors.toList());
+  }
+
 }

--- a/src/main/java/com/blog/domain/user/controller/UserController.java
+++ b/src/main/java/com/blog/domain/user/controller/UserController.java
@@ -1,18 +1,33 @@
 package com.blog.domain.user.controller;
 
+import com.blog.domain.comment.dto.CommentResponse;
+import com.blog.domain.comment.service.CommentService;
+import com.blog.domain.post.dto.PostResponse;
+import com.blog.domain.post.service.PostService;
 import com.blog.domain.user.domain.User;
+import com.blog.domain.user.dto.UpdateProfileImageRequest;
+import com.blog.domain.user.dto.UserProfileResponse;
+import com.blog.domain.user.service.UserService;
 import com.blog.global.auth.service.AuthService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class UserController {
   private final AuthService authService;
+  private final UserService userService;
+  private final PostService postService;
+  private final CommentService commentService;
 
-  public UserController(AuthService authService) {
+  public UserController(AuthService authService, UserService userService , PostService postService , CommentService commentService) {
     this.authService = authService;
+    this.userService = userService;
+    this.postService = postService;
+    this.commentService = commentService;
   }
 
   @GetMapping("/protected-resource")
@@ -21,5 +36,58 @@ public class UserController {
     User user = authService.getUserInfoFromToken(token);
     return ResponseEntity.ok(user);
   }
-}
 
+  @GetMapping("/me")
+  public ResponseEntity<UserProfileResponse> getMyInfo(
+      @RequestHeader("Authorization") String token) {
+    User user = getUserFromToken(token);
+    return ResponseEntity.ok(UserProfileResponse.from(user));
+  }
+
+  @DeleteMapping("/me")
+  public ResponseEntity<Map<String, String>> deleteMyAccount(
+      @RequestHeader("Authorization") String token) {
+    User user = getUserFromToken(token);
+    userService.deleteByEmail(user.getEmail());
+
+    Map<String, String> response = Map.of("message", "회원 탈퇴가 완료되었습니다.");
+    return ResponseEntity.ok(response);
+  }
+
+  @PatchMapping("/me/profile-image")
+  public ResponseEntity<Map<String, String>> updateProfileImage(
+      @RequestHeader("Authorization") String token,
+      @RequestBody UpdateProfileImageRequest request) {
+    User user = getUserFromToken(token);
+    userService.updateProfileImage(user.getEmail(), request.getProfileImageUrl());
+
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "프로필 이미지가 성공적으로 변경되었습니다.");
+    response.put("profileImageUrl", request.getProfileImageUrl());
+
+    return ResponseEntity.ok(response);
+  }
+
+  private User getUserFromToken(String token) {
+    User decoded = authService.getUserInfoFromToken(token);
+    return userService.findUserByEmail(decoded.getEmail())
+        .orElseThrow(() -> new RuntimeException("User not found"));
+  }
+
+  @GetMapping("/me/posts")
+  public ResponseEntity<List<PostResponse>> getMyPosts(
+      @RequestHeader("Authorization") String token) {
+    User user = getUserFromToken(token);
+    List<PostResponse> posts = postService.getPostsByAuthor(user.getId());
+    return ResponseEntity.ok(posts);
+  }
+
+  @GetMapping("/me/comments")
+  public ResponseEntity<List<CommentResponse>> getMyComments(
+      @RequestHeader("Authorization") String token) {
+    User user = getUserFromToken(token);
+    List<CommentResponse> comments = commentService.getCommentsByAuthor(user.getId());
+    return ResponseEntity.ok(comments);
+  }
+
+}

--- a/src/main/java/com/blog/domain/user/dto/UpdateProfileImageRequest.java
+++ b/src/main/java/com/blog/domain/user/dto/UpdateProfileImageRequest.java
@@ -1,0 +1,9 @@
+package com.blog.domain.user.dto;
+
+public class UpdateProfileImageRequest {
+  private String profileImageUrl;
+
+  public String getProfileImageUrl() {
+    return profileImageUrl;
+  }
+}

--- a/src/main/java/com/blog/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/blog/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,51 @@
+package com.blog.domain.user.dto;
+
+import com.blog.domain.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class UserProfileResponse {
+  private UUID id;
+  private String nickname;
+  private String email;
+  private String profileImageUrl;
+  private LocalDateTime createdAt;
+
+  public UserProfileResponse(UUID id, String nickname, String email, String profileImageUrl, LocalDateTime createdAt) {
+    this.id = id;
+    this.nickname = nickname;
+    this.email = email;
+    this.profileImageUrl = profileImageUrl;
+    this.createdAt = createdAt;
+  }
+
+  public static UserProfileResponse from(User user) {
+    return new UserProfileResponse(
+        user.getId(),
+        user.getNickname(),
+        user.getEmail(),
+        user.getProfileImageUrl(),
+        user.getCreatedAt()
+    );
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getNickname() {
+    return nickname;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getProfileImageUrl() {
+    return profileImageUrl;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/src/main/java/com/blog/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/blog/domain/user/repository/UserRepository.java
@@ -45,6 +45,12 @@ public class UserRepository {
     return users.stream().findFirst();
   }
 
+  public void deleteByEmail(String email) {
+    String sql = "DELETE FROM user WHERE email = ?";
+    jdbcTemplate.update(sql, email);
+  }
+
+
   private RowMapper<User> userRowMapper() {
     return (rs, rowNum) -> new User(
         UUID.fromString(rs.getString("id")),

--- a/src/main/java/com/blog/domain/user/service/UserService.java
+++ b/src/main/java/com/blog/domain/user/service/UserService.java
@@ -11,15 +11,18 @@ import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 public class UserService {
   private final UserRepository userRepository;
+  private final JdbcTemplate jdbcTemplate;
   private static final String SALT = "random_salt_value";
 
-  public UserService(UserRepository userRepository) {
+  public UserService(UserRepository userRepository, JdbcTemplate jdbcTemplate) {
     this.userRepository = userRepository;
+    this.jdbcTemplate = jdbcTemplate;
   }
 
   public void registerUser(String nickname, String password, String email, String profileImageUrl) {
@@ -42,4 +45,14 @@ public class UserService {
   public Optional<User> findUserByEmail(String email) {
     return userRepository.findByEmail(email);
   }
+
+  public void deleteByEmail(String email) {
+    userRepository.deleteByEmail(email);
+  }
+
+  public void updateProfileImage(String email, String imageUrl) {
+    String sql = "UPDATE user SET profile_image_url = ?, updated_at = ? WHERE email = ?";
+    jdbcTemplate.update(sql, imageUrl, LocalDateTime.now(), email);
+  }
+
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

사용자가 자신의 정보를 관리할 수 있도록 다음과 같은 기능들을 구현했습니다.

- 내 정보 조회
- 회원 탈퇴
- 프로필 이미지 변경
- 내가 쓴 게시글 목록 조회
- 내가 쓴 댓글 목록 조회



## 2. 어떤 위험이나 장애를 발견했나요?

- 인증 토큰에서 이메일만 파싱되기 때문에, 삭제된 유저 정보 요청 시 404 처리 필요.
- UUID 파싱 실패 시 예외 발생 가능 → 클라이언트 입력값에 대한 사전 검증이 필요함.



## 3. 관련 스크린샷을 첨부해주세요.
- 내 정보 조회
<img width="853" alt="스크린샷 2025-05-06 오후 10 39 16" src="https://github.com/user-attachments/assets/ccac3ec8-fae2-40d5-9e17-ec4f4fdb034b" />

- 프로필 이미지 변경
<img width="854" alt="스크린샷 2025-05-06 오후 10 40 26" src="https://github.com/user-attachments/assets/3a7839ba-710c-472b-a05f-d1b2e4eecb60" />

- 내가 쓴 게시글 목록 조회
<img width="848" alt="스크린샷 2025-05-06 오후 10 41 37" src="https://github.com/user-attachments/assets/4bb1d319-9dff-4467-bf29-f977c7de4cfb" />

- 내가 쓴 댓글 목록 조회
<img width="855" alt="스크린샷 2025-05-06 오후 10 46 24" src="https://github.com/user-attachments/assets/746e0c0e-4ced-4ada-a80f-9108648bd1e9" />

- 회원 탈퇴
<img width="848" alt="스크린샷 2025-05-06 오후 11 01 34" src="https://github.com/user-attachments/assets/866bee60-1da1-41af-a0e0-f8258626d33b" />



## 4. 완료 사항

* [x] `/me` : 사용자 본인 정보 조회
* [x] `DELETE /me` : 사용자 본인 계정 탈퇴
* [x] `PATCH /me/profile-image` : 프로필 이미지 변경
* [x] `GET /me/posts` : 내가 쓴 게시글 목록 조회
* [x] `GET /me/comments` : 내가 쓴 댓글 목록 조회
* [x] 모든 응답을 JSON 형태로 반환하도록 통일

closed #80 